### PR TITLE
add support to pass a Bitmap to setImage

### DIFF
--- a/gravityview/src/main/java/co/gofynd/gravityview/GravityView.java
+++ b/gravityview/src/main/java/co/gofynd/gravityview/GravityView.java
@@ -60,8 +60,31 @@ public class GravityView implements SensorEventListener {
         return gravityView;
     }
 
+    public GravityView setImage(ImageView image, Bitmap bitmap) {
+        image_view = image;
+        Bitmap bmp = resizeBitmap(Common.getDeviceHeight(mContext), bitmap);
+        image_view.setLayoutParams(new HorizontalScrollView.LayoutParams(bmp.getWidth(), bmp.getHeight()));
+        image_view.setImageBitmap(bmp);
+        mMaxScroll = bmp.getWidth();
+        if (image.getParent() instanceof HorizontalScrollView) {
+            ((HorizontalScrollView) image.getParent()).setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View view, MotionEvent motionEvent) {
+                    return true;
+                }
+            });
+        }
+        return gravityView;
+    }
+
     private Bitmap resizeBitmap(int targetH, int drawable) {
         Bitmap bitmap = BitmapFactory.decodeResource(mContext.getResources(), drawable);
+        mImageWidth = (bitmap.getWidth() * Common.getDeviceHeight(mContext)) / bitmap.getHeight();
+
+        return Bitmap.createScaledBitmap(bitmap, mImageWidth, targetH, true);
+    }
+
+    private Bitmap resizeBitmap(int targetH, Bitmap bitmap) {
         mImageWidth = (bitmap.getWidth() * Common.getDeviceHeight(mContext)) / bitmap.getHeight();
 
         return Bitmap.createScaledBitmap(bitmap, mImageWidth, targetH, true);


### PR DESCRIPTION
When using a library such as Picasso to load images from an URL, the image does not have a resource identifier because it is not part of the application.
This PR adds the capability to pass a Bitmap to gravity-view.
A typical usage scenario using Picasso's Targets is as follows:
```
  @Override
    public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
        if (gravityView.deviceSupported()) {
            gravityView
                    .setImage(backgroundImageView, bitmap)
                    .center();
        } else {
            Drawable drawable = new BitmapDrawable(getResources(), bitmap);
            if (drawable != null) {
                holder.setBackgroundDrawable(drawable);
            }
        }
    }
```